### PR TITLE
Exit Immediately when Command Fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a guide on how to set up Cilium on [Google GKE](https://cloud.google.com
 
    ```
    export ADMIN_USER=user@email.com
-   glcoud auth login
+   gcloud auth login
    ```
 
    The `$ADMIN_USER` will be used to create a cluster role binding

--- a/create-gke-cluster.sh
+++ b/create-gke-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if [ -z "$ADMIN_USER" ]; then
 	echo "ADMIN_USER is not set"


### PR DESCRIPTION
Currently, the script moves on regardless. This change abort the
script when a command fails.