### PR TITLE
Fix typo in create-gke-cluster script

### DIFF
--- a/create-gke-cluster.sh
+++ b/create-gke-cluster.sh
@@ -10,7 +10,7 @@ GKE_PROJECT="${GKE_PROJECT:-default-project}"
 GKE_REGION="${GKE_REGION:-europe-north1}"
 GKE_ZONE="${GKE_ZONE:--a}"
 IMAGE_TYPE="${IMAGE_TYPE:-COS}"
-NUM_NODES=${NUM_NODES:3}"
+NUM_NODES="${NUM_NODES:-3}"
 
 default_version=$(gcloud container get-server-config --project $GKE_PROJECT --zone europe-north1-a | grep 1.11 | head -n 1 | awk '{print $2}')
 GKE_VERSION=${GKE_VERSION:-$default_version}


### PR DESCRIPTION
Fix for broken `create-gke-cluster` script.